### PR TITLE
Fix YOLO config terminology

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -8,7 +8,7 @@ TASKS_IDS = []
 PROJECTS_IDS = [] # List of projects ids to download
 
 [DATASET]
-FORMAT = # Format of dataset (e.g. coco, voc). Add yolov8 format support (yolo_boxes, yolo_seg)
+FORMAT = # Format of dataset (e.g. coco, voc). Add yolov8 format support (yolo_det, yolo_seg)
 RAW_DATA_PATH = # Path to downloaded dataset
 SAVE_PATH = # Path to save dataset
 SPLIT = {'train': 0.8, 'val': 0.2} 


### PR DESCRIPTION
## Summary
- fix comment in config.ini to reference `yolo_det`

## Testing
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846ccef38488326b1cb857bca8703a6