### PR TITLE
Fix int casting in backup_tasks_from_cvat

### DIFF
--- a/cvat_data_flow/src/cvat_api.py
+++ b/cvat_data_flow/src/cvat_api.py
@@ -174,7 +174,12 @@ class CVAT_API:
 
     def backup_tasks_from_cvat(self, tasks: List[Union[Task, int]]) -> None:
         """Backup tasks from CVAT."""
-        tasks = [self.client.tasks.retrieve(task) if not isinstance(task, Task) else task for task in tasks]
+        tasks = [
+            self.client.tasks.retrieve(int(task))
+            if not isinstance(task, Task)
+            else task
+            for task in tasks
+        ]
 
         for task in tqdm(tasks):
             self._backup(task)


### PR DESCRIPTION
## Summary
- ensure task IDs are cast to int when retrieving tasks for backup

## Testing
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846ccee03108326bf82ab642569c5aa